### PR TITLE
0.3.1

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>ovh.mythmc</groupId>
         <artifactId>social</artifactId>
-        <version>0.3.0</version>
+        <version>0.3.1</version>
     </parent>
 
     <properties>

--- a/api/src/main/java/ovh/mythmc/social/api/configuration/sections/settings/PacketsSettings.java
+++ b/api/src/main/java/ovh/mythmc/social/api/configuration/sections/settings/PacketsSettings.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 @Getter
 public class PacketsSettings {
 
-    @Comment("Whether packet-based features should be enabled or not")
+    @Comment({"Whether packet-based features should be enabled or not", "Requires PacketEvents to work: https://github.com/retrooper/packetevents/"})
     private boolean enabled = true;
 
     @Comment("Emoji tab completion in chat")

--- a/api/src/main/java/ovh/mythmc/social/api/context/SocialParserContext.java
+++ b/api/src/main/java/ovh/mythmc/social/api/context/SocialParserContext.java
@@ -30,7 +30,8 @@ public class SocialParserContext implements SocialContext {
 
     private final Component message;
 
-    private final ChannelType messageChannelType;
+    @Builder.Default
+    private final ChannelType messageChannelType = ChannelType.CHAT;
 
     @Builder.Default private final List<Class<?>> appliedParsers = new ArrayList<>();
 

--- a/api/src/main/java/ovh/mythmc/social/api/text/GlobalTextProcessor.java
+++ b/api/src/main/java/ovh/mythmc/social/api/text/GlobalTextProcessor.java
@@ -213,21 +213,18 @@ public final class GlobalTextProcessor {
     }
 
     @ApiStatus.Experimental
-    public void sendToConsole(final @NotNull CommandSender commandSender,
-                              @NotNull Component message) {
+    public void sendToConsole(final @NotNull CommandSender commandSender, @NotNull Component message) {
         // Todo: parse?
         SocialAdventureProvider.get().sender(commandSender).sendMessage(message);
     }
 
-    public void send(final @NotNull SocialPlayer recipient,
-                     @NotNull Component message,
-                     final @NotNull ChannelType type) {
+    public void send(final @NotNull SocialPlayer recipient, @NotNull Component message, final @NotNull ChannelType type) {
         send(List.of(recipient), message, type);
     }
 
-    public void send(final @NotNull Collection<SocialPlayer> members,
-                     @NotNull Component message,
-                     final @NotNull ChannelType type) {
+    public void send(final @NotNull Collection<SocialPlayer> members, @NotNull Component message, final @NotNull ChannelType type) {
+        if (message == null || message.equals(Component.empty()))
+            return;
 
         members.forEach(socialPlayer -> SocialAdventureProvider.get().sendMessage(socialPlayer, message, type));
     }

--- a/api/src/main/java/ovh/mythmc/social/api/text/GlobalTextProcessor.java
+++ b/api/src/main/java/ovh/mythmc/social/api/text/GlobalTextProcessor.java
@@ -92,6 +92,12 @@ public final class GlobalTextProcessor {
             unregisterParser(placeholder);
     }
 
+    public void unregisterAllParsers() {
+        EARLY_PARSERS.removeAll();
+        parsers.clear();
+        LATE_PARSERS.removeAll();
+    }
+
     public List<SocialParser> getParsers() {
         List<SocialParser> parserList = new ArrayList<>();
         parserList.addAll(EARLY_PARSERS.get());

--- a/api/src/main/java/ovh/mythmc/social/api/text/group/SocialParserGroup.java
+++ b/api/src/main/java/ovh/mythmc/social/api/text/group/SocialParserGroup.java
@@ -31,6 +31,10 @@ public class SocialParserGroup implements SocialContextualParser {
         Arrays.stream(parsers).forEach(content::remove);
     }
 
+    public void removeAll() {
+        get().forEach(content::remove);
+    }
+
     @Experimental
     public Component requestToGroup(@NotNull SocialContextualParser requester, @NotNull SocialParserContext context) {
         return request(context, content.stream().filter(parser -> !parser.getClass().equals(requester.getClass())).toList());

--- a/platform-bukkit/pom.xml
+++ b/platform-bukkit/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>ovh.mythmc</groupId>
         <artifactId>social</artifactId>
-        <version>0.3.0</version>
+        <version>0.3.1</version>
     </parent>
 
     <properties>

--- a/platform-bukkit/src/main/resources/plugin.yml
+++ b/platform-bukkit/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ version: '${project.version}'
 api-version: 1.19
 
 main: ovh.mythmc.social.bukkit.SocialBukkitPlugin
-softdepend: [ PlaceholderAPI, DiscordSRV, gestalt ]
+softdepend: [ PlaceholderAPI, DiscordSRV, packetevents, gestalt ]
 
 libraries:
   - net.kyori:adventure-api:4.12.0

--- a/platform-common/pom.xml
+++ b/platform-common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>ovh.mythmc</groupId>
         <artifactId>social</artifactId>
-        <version>0.3.0</version>
+        <version>0.3.1</version>
     </parent>
 
     <properties>

--- a/platform-common/pom.xml
+++ b/platform-common/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>com.discordsrv</groupId>
             <artifactId>discordsrv</artifactId>
-            <version>1.28.0</version>
+            <version>1.29.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/platform-common/src/main/java/ovh/mythmc/social/common/boot/SocialBootstrap.java
+++ b/platform-common/src/main/java/ovh/mythmc/social/common/boot/SocialBootstrap.java
@@ -70,8 +70,8 @@ public abstract class SocialBootstrap<T> implements Social {
     public final void reload() {
         Gestalt.get().disableFeature(BootstrapFeature.class);
 
-        // Clear parsers
-        Social.get().getTextProcessor().getParsers().clear();
+        // Unregister all parsers
+        Social.get().getTextProcessor().unregisterAllParsers();
 
         // Reload settings.yml and messages.yml
         getConfig().load();

--- a/platform-common/src/main/java/ovh/mythmc/social/common/features/PacketsFeature.java
+++ b/platform-common/src/main/java/ovh/mythmc/social/common/features/PacketsFeature.java
@@ -1,7 +1,6 @@
 package ovh.mythmc.social.common.features;
 
 import com.github.retrooper.packetevents.PacketEvents;
-import com.github.retrooper.packetevents.settings.PacketEventsSettings;
 import io.github.retrooper.packetevents.factory.spigot.SpigotPacketEventsBuilder;
 
 import org.bukkit.Bukkit;
@@ -13,7 +12,6 @@ import ovh.mythmc.gestalt.annotations.Feature;
 import ovh.mythmc.gestalt.annotations.conditions.FeatureConditionBoolean;
 import ovh.mythmc.gestalt.annotations.status.FeatureDisable;
 import ovh.mythmc.gestalt.annotations.status.FeatureEnable;
-import ovh.mythmc.gestalt.annotations.status.FeatureInitialize;
 import ovh.mythmc.gestalt.annotations.status.FeatureShutdown;
 import ovh.mythmc.social.api.Social;
 import ovh.mythmc.social.common.listeners.PacketsListener;
@@ -23,7 +21,7 @@ public final class PacketsFeature {
 
     private final JavaPlugin plugin;
 
-    private final PacketsListener packetsListener = new PacketsListener();
+    private PacketsListener packetsListener;
 
     public PacketsFeature(@NotNull JavaPlugin plugin) {
         this.plugin = plugin;
@@ -31,29 +29,21 @@ public final class PacketsFeature {
 
     @FeatureConditionBoolean
     public boolean canBeEnabled() {
-        return isSupported() && Social.get().getConfig().getSettings().getPackets().isEnabled();
+        return isSupported() && Bukkit.getPluginManager().isPluginEnabled("PacketEvents") && Social.get().getConfig().getSettings().getPackets().isEnabled();
     }
 
-    @FeatureInitialize
-    public void initialize() {
-        if(!isSupported())
-            return;
+    @FeatureEnable
+    public void enable() {        
+        this.packetsListener = new PacketsListener();
 
         PacketEvents.setAPI(SpigotPacketEventsBuilder.build(plugin));
-
-        // Disable update checker
-        PacketEventsSettings settings = PacketEvents.getAPI().getSettings();
-        settings.checkForUpdates(false);
 
         // Load PacketEvents API
         PacketEvents.getAPI().load();
 
         // Initialize PacketEvents API
         PacketEvents.getAPI().init();
-    }
 
-    @FeatureEnable
-    public void enable() {
         Bukkit.getPluginManager().registerEvents(packetsListener, plugin);
     }
 

--- a/platform-common/src/main/java/ovh/mythmc/social/common/features/ServerLinksFeature.java
+++ b/platform-common/src/main/java/ovh/mythmc/social/common/features/ServerLinksFeature.java
@@ -5,6 +5,7 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 
+import ovh.mythmc.gestalt.Gestalt;
 import ovh.mythmc.gestalt.annotations.Feature;
 import ovh.mythmc.gestalt.annotations.conditions.FeatureConditionBoolean;
 import ovh.mythmc.gestalt.annotations.conditions.FeatureConditionVersion;
@@ -19,7 +20,7 @@ public final class ServerLinksFeature {
 
     private final JavaPlugin plugin;
 
-    private final ServerLinksListener serverLinksListener = new ServerLinksListener();
+    private ServerLinksListener serverLinksListener;
 
     public ServerLinksFeature(@NotNull JavaPlugin plugin) {
         this.plugin = plugin;
@@ -28,11 +29,13 @@ public final class ServerLinksFeature {
     @FeatureConditionBoolean
     public boolean canBeEnabled() {
         return Social.get().getConfig().getSettings().getPackets().isEnabled() &&
-                Social.get().getConfig().getSettings().getPackets().getServerLinks().isEnabled();
+                Social.get().getConfig().getSettings().getPackets().getServerLinks().isEnabled() &&
+                Gestalt.get().isEnabled(PacketsFeature.class);
     }
 
     @FeatureEnable
     public void enable() {
+        this.serverLinksListener = new ServerLinksListener();
         Bukkit.getPluginManager().registerEvents(serverLinksListener, plugin);
     }
 

--- a/platform-common/src/main/java/ovh/mythmc/social/common/features/hooks/DiscordSRVFeature.java
+++ b/platform-common/src/main/java/ovh/mythmc/social/common/features/hooks/DiscordSRVFeature.java
@@ -1,6 +1,7 @@
 package ovh.mythmc.social.common.features.hooks;
 
 import org.bukkit.Bukkit;
+import org.bukkit.event.HandlerList;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import github.scarsz.discordsrv.DiscordSRV;
@@ -9,6 +10,7 @@ import ovh.mythmc.gestalt.annotations.Feature;
 import ovh.mythmc.gestalt.annotations.conditions.FeatureConditionBoolean;
 import ovh.mythmc.gestalt.annotations.status.FeatureDisable;
 import ovh.mythmc.gestalt.annotations.status.FeatureEnable;
+import ovh.mythmc.gestalt.annotations.status.FeatureInitialize;
 import ovh.mythmc.social.api.Social;
 import ovh.mythmc.social.common.hooks.DiscordSRVDeathListener;
 import ovh.mythmc.social.common.hooks.DiscordSRVHook;
@@ -28,19 +30,24 @@ public final class DiscordSRVFeature {
         return Bukkit.getPluginManager().isPluginEnabled("DiscordSRV");
     }
 
-    @FeatureEnable
-    public void enable() {
+    @FeatureInitialize
+    public void initialize() {
         this.hook = new DiscordSRVHook(plugin);
         this.deathListener = new DiscordSRVDeathListener();
+    }
 
+    @FeatureEnable
+    public void enable() {
         // Register hook and subscribe to API events
         DiscordSRV.getPlugin().getPluginHooks().add(hook);
         DiscordSRV.api.subscribe(hook);
 
+        // Register Bukkit listeners
+        Bukkit.getPluginManager().registerEvents(hook, plugin);
+
         // Register death listener if custom system messages are enabled
         if (Social.get().getConfig().getSettings().getSystemMessages().isEnabled() &&
             Social.get().getConfig().getSettings().getSystemMessages().isCustomizeDeathMessage()) {
-            
             Bukkit.getPluginManager().registerEvents(deathListener, plugin);
         }
         
@@ -48,7 +55,8 @@ public final class DiscordSRVFeature {
 
     @FeatureDisable
     public void disable() {
-
+        // Unregister Bukkit listeners
+        HandlerList.unregisterAll(deathListener);
     }
     
 }

--- a/platform-common/src/main/java/ovh/mythmc/social/common/listeners/ChatListener.java
+++ b/platform-common/src/main/java/ovh/mythmc/social/common/listeners/ChatListener.java
@@ -10,9 +10,11 @@ import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import lombok.RequiredArgsConstructor;
+import net.kyori.adventure.text.Component;
 import ovh.mythmc.social.api.Social;
 import ovh.mythmc.social.api.chat.ChatChannel;
 import ovh.mythmc.social.api.context.SocialMessageContext;
+import ovh.mythmc.social.api.context.SocialParserContext;
 import ovh.mythmc.social.api.events.chat.*;
 import ovh.mythmc.social.api.players.SocialPlayer;
 import ovh.mythmc.social.common.util.PluginUtil;
@@ -166,7 +168,13 @@ public final class ChatListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onSocialChannelPostSwitch(SocialChannelPostSwitchEvent event) {
-        Social.get().getTextProcessor().parseAndSend(event.getSocialPlayer(), event.getChatChannel(), Social.get().getConfig().getMessages().getCommands().getChannelChanged(), Social.get().getConfig().getMessages().getChannelType());
+        SocialParserContext context = SocialParserContext.builder()
+            .socialPlayer(event.getSocialPlayer())
+            .playerChannel(event.getChatChannel())
+            .message(Component.text(Social.get().getConfig().getMessages().getCommands().getChannelChanged()))
+            .build();
+
+        Social.get().getTextProcessor().parseAndSend(context);
     }
 
     private Integer tryParse(String text) {

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ovh.mythmc</groupId>
     <artifactId>social</artifactId>
-    <version>0.3.0</version>
+    <version>0.3.1</version>
     <packaging>pom</packaging>
     <modules>
         <module>api</module>

--- a/pom.xml
+++ b/pom.xml
@@ -247,8 +247,8 @@
         <dependency>
             <groupId>com.github.retrooper</groupId>
             <artifactId>packetevents-spigot</artifactId>
-            <version>2.6.0</version>
-            <scope>compile</scope>
+            <version>2.7.0</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
- fix(discordsrv): messages aren't sent from Minecraft to Discord
- fix: early and late parser groups aren't unregistered when reloading the plug-in, leading to duplicates
- fix: empty messages shouldn't be sent (#14)