### PR TITLE
0.4.1

### DIFF
--- a/api/src/main/java/ovh/mythmc/social/api/chat/ChatHistory.java
+++ b/api/src/main/java/ovh/mythmc/social/api/chat/ChatHistory.java
@@ -33,7 +33,7 @@ public final class ChatHistory {
             finalMessage, 
             messageContext.rawMessage(), 
             messageContext.replyId(),
-            messageContext.signedMessage());
+            messageContext.signedMessage().orElse(null));
 
         messages.put(id, historyContext);
         return historyContext;
@@ -44,11 +44,11 @@ public final class ChatHistory {
     }
 
     public boolean canDelete(SocialMessageContext context) {
-        return context.isSigned() ? context.signedMessage().canDelete() : false;
+        return context.signedMessage().isPresent() ? context.signedMessage().get().canDelete() : false;
     }
 
     public void delete(SocialRegisteredMessageContext context) {
-        Social.get().getUserManager().get().forEach(user -> user.deleteMessage(context.signedMessage()));
+        Social.get().getUserManager().get().forEach(user -> user.deleteMessage(context.signedMessage().get()));
 
         SocialRegisteredMessageContext newContext = new SocialRegisteredMessageContext(
             context.id(), 
@@ -59,7 +59,7 @@ public final class ChatHistory {
             Component.text("N/A", NamedTextColor.RED), 
             context.rawMessage(), 
             context.replyId(), 
-            context.signedMessage());
+            context.signedMessage().orElse(null));
 
         messages.put(context.id(), newContext);
     }

--- a/api/src/main/java/ovh/mythmc/social/api/chat/ChatManager.java
+++ b/api/src/main/java/ovh/mythmc/social/api/chat/ChatManager.java
@@ -241,12 +241,12 @@ public final class ChatManager {
 
                 Component filteredMessage = parsePlayerInput(sender, sender.getMainChannel(), message);
 
-                if (!sender.getNickname().equals(senderPlayer.getName()))
+                if (!sender.getCachedNickname().equals(senderPlayer.getName()))
                     senderHoverText = senderHoverText
                             .appendNewline()
                             .append(parse(sender, sender.getMainChannel(), Social.get().getConfig().getChat().getPlayerAliasWarningHoverText()));
 
-                if (!recipient.getNickname().equals(recipientPlayer.getName()))
+                if (!recipient.getCachedNickname().equals(recipientPlayer.getName()))
                     recipientHoverText = recipientHoverText
                             .appendNewline()
                             .append(parse(recipient, recipient.getMainChannel(), Social.get().getConfig().getChat().getPlayerAliasWarningHoverText()));
@@ -278,7 +278,7 @@ public final class ChatManager {
                 Social.get().getUserManager().setLatestMessage(sender, System.currentTimeMillis());
 
                 // Send message to console
-                SocialAdventureProvider.get().console().sendMessage(Component.text("[PM] " + sender.getNickname() + " -> " + recipient.getNickname() + ": " + message));
+                SocialAdventureProvider.get().console().sendMessage(Component.text("[PM] " + sender.getCachedNickname() + " -> " + recipient.getCachedNickname() + ": " + message));
             });
         });
     }

--- a/api/src/main/java/ovh/mythmc/social/api/chat/ChatManager.java
+++ b/api/src/main/java/ovh/mythmc/social/api/chat/ChatManager.java
@@ -241,12 +241,12 @@ public final class ChatManager {
 
                 Component filteredMessage = parsePlayerInput(sender, sender.getMainChannel(), message);
 
-                if (!sender.getCachedNickname().equals(senderPlayer.getName()))
+                if (!sender.getCachedDisplayName().equals(senderPlayer.getName()))
                     senderHoverText = senderHoverText
                             .appendNewline()
                             .append(parse(sender, sender.getMainChannel(), Social.get().getConfig().getChat().getPlayerAliasWarningHoverText()));
 
-                if (!recipient.getCachedNickname().equals(recipientPlayer.getName()))
+                if (!recipient.getCachedDisplayName().equals(recipientPlayer.getName()))
                     recipientHoverText = recipientHoverText
                             .appendNewline()
                             .append(parse(recipient, recipient.getMainChannel(), Social.get().getConfig().getChat().getPlayerAliasWarningHoverText()));
@@ -278,7 +278,7 @@ public final class ChatManager {
                 Social.get().getUserManager().setLatestMessage(sender, System.currentTimeMillis());
 
                 // Send message to console
-                SocialAdventureProvider.get().console().sendMessage(Component.text("[PM] " + sender.getCachedNickname() + " -> " + recipient.getCachedNickname() + ": " + message));
+                SocialAdventureProvider.get().console().sendMessage(Component.text("[PM] " + sender.getCachedDisplayName() + " -> " + recipient.getCachedDisplayName() + ": " + message));
             });
         });
     }

--- a/api/src/main/java/ovh/mythmc/social/api/chat/renderer/SocialChatRendererUtil.java
+++ b/api/src/main/java/ovh/mythmc/social/api/chat/renderer/SocialChatRendererUtil.java
@@ -61,7 +61,8 @@ public class SocialChatRendererUtil {
         Component hoverText = Component.empty();
         for (SocialRegisteredMessageContext threadReply : Social.get().getChatManager().getHistory().getThread(reply, 8)) {
             hoverText = hoverText
-                .append(Component.text(threadReply.sender().getNickname() + ": ", NamedTextColor.GRAY))
+                .append(threadReply.sender().displayName())
+                .append(Component.text(": ", NamedTextColor.GRAY))
                 .append(threadReply.message())
                 .appendNewline();
         }

--- a/api/src/main/java/ovh/mythmc/social/api/chat/renderer/defaults/UserChatRenderer.java
+++ b/api/src/main/java/ovh/mythmc/social/api/chat/renderer/defaults/UserChatRenderer.java
@@ -44,7 +44,7 @@ public class UserChatRenderer implements SocialChatRenderer<SocialUser> {
         var renderedPrefix = Social.get().getTextProcessor().parse(SocialParserContext.builder(sender, prefix).channel(channel).build());
 
         // Send as channelable message to companion mod
-        if (target.isCompanion())
+        if (target.companion().isPresent())
             renderedPrefix = CompanionModUtils.asChannelable(renderedPrefix, channel);
 
         return new SocialRendererContext(

--- a/api/src/main/java/ovh/mythmc/social/api/configuration/LegacySocialSettings.java
+++ b/api/src/main/java/ovh/mythmc/social/api/configuration/LegacySocialSettings.java
@@ -41,4 +41,7 @@ public final class LegacySocialSettings implements SocialSettings {
     @Comment({"", "Commands settings"})
     private CommandsSettings commands = new CommandsSettings();
 
+    @Comment({"", "Database settings"})
+    private DatabaseSettings databaseSettings = new DatabaseSettings();
+
 }

--- a/api/src/main/java/ovh/mythmc/social/api/configuration/ModernSocialSettings.java
+++ b/api/src/main/java/ovh/mythmc/social/api/configuration/ModernSocialSettings.java
@@ -5,6 +5,7 @@ import ovh.mythmc.social.api.Social;
 import ovh.mythmc.social.api.configuration.section.settings.AnnouncementsSettings;
 import ovh.mythmc.social.api.configuration.section.settings.ChatSettings;
 import ovh.mythmc.social.api.configuration.section.settings.CommandsSettings;
+import ovh.mythmc.social.api.configuration.section.settings.DatabaseSettings;
 import ovh.mythmc.social.api.configuration.section.settings.EmojiSettings;
 import ovh.mythmc.social.api.configuration.section.settings.GeneralSettings;
 import ovh.mythmc.social.api.configuration.section.settings.MOTDSettings;
@@ -35,5 +36,7 @@ public final class ModernSocialSettings implements SocialSettings {
     private TextReplacementSettings textReplacement = Social.get().getConfig().getTextReplacement();
 
     private CommandsSettings commands = Social.get().getConfig().getCommands();
+
+    private DatabaseSettings databaseSettings = Social.get().getConfig().getDatabaseSettings();
 
 }

--- a/api/src/main/java/ovh/mythmc/social/api/configuration/SocialSettings.java
+++ b/api/src/main/java/ovh/mythmc/social/api/configuration/SocialSettings.java
@@ -3,6 +3,7 @@ package ovh.mythmc.social.api.configuration;
 import ovh.mythmc.social.api.configuration.section.settings.AnnouncementsSettings;
 import ovh.mythmc.social.api.configuration.section.settings.ChatSettings;
 import ovh.mythmc.social.api.configuration.section.settings.CommandsSettings;
+import ovh.mythmc.social.api.configuration.section.settings.DatabaseSettings;
 import ovh.mythmc.social.api.configuration.section.settings.EmojiSettings;
 import ovh.mythmc.social.api.configuration.section.settings.GeneralSettings;
 import ovh.mythmc.social.api.configuration.section.settings.MOTDSettings;
@@ -32,5 +33,7 @@ public interface SocialSettings {
     TextReplacementSettings getTextReplacement();
 
     CommandsSettings getCommands();
+
+    DatabaseSettings getDatabaseSettings();
 
 }

--- a/api/src/main/java/ovh/mythmc/social/api/configuration/section/messages/CommandsMessages.java
+++ b/api/src/main/java/ovh/mythmc/social/api/configuration/section/messages/CommandsMessages.java
@@ -47,4 +47,12 @@ public class CommandsMessages {
 
     private String userUnmutedGlobally = "$(success_prefix) <gray>User <blue>%s</blue> has been unmuted globally.</gray>";
 
+    private String processorResult = "$(info_prefix) <blue>Result: </blue>";
+
+    private String processorClickToAnnounce = "$(warning_prefix) <gray>Click here to broadcast this message</gray>";
+
+    private String processorInfoParsers = "$(info_prefix) %s <gray>registered parsers (<white>%s</white> groups)</gray>";
+
+    private String processorInfoParsersByType = "$(info_prefix) :raw_box_up_and_right: <gray>%s</gray>: %s";
+
 }

--- a/api/src/main/java/ovh/mythmc/social/api/configuration/section/messages/ErrorsMessages.java
+++ b/api/src/main/java/ovh/mythmc/social/api/configuration/section/messages/ErrorsMessages.java
@@ -17,6 +17,8 @@ public class ErrorsMessages {
 
     private String invalidArgument = "$(error_prefix) <red>Invalid argument <gray>%s</gray> for type <gray>%s</gray>.</red>";
 
+    private String unknownAnnouncement = "$(error_prefix) <red>Unknown announcement.</red>";
+
     private String notEnoughPermission = "$(error_prefix) <red>You do not have enough permission to do this.</red>";
 
     private String notEnoughArguments = "$(error_prefix) <red>Not enough arguments.</red>";

--- a/api/src/main/java/ovh/mythmc/social/api/configuration/section/settings/DatabaseSettings.java
+++ b/api/src/main/java/ovh/mythmc/social/api/configuration/section/settings/DatabaseSettings.java
@@ -1,0 +1,30 @@
+package ovh.mythmc.social.api.configuration.section.settings;
+
+import de.exlll.configlib.Comment;
+import de.exlll.configlib.Configuration;
+import lombok.Getter;
+
+@Configuration
+@Getter
+public class DatabaseSettings {
+
+    @Comment("Database type (SQLITE, MYSQL or MARIADB)")
+    private DatabaseType type = DatabaseType.SQLITE;
+
+    @Comment("Time between each cache clean in minutes")
+    private int cacheClearInterval = 5;
+
+    @Comment("Don't change this, you might lose all your data")
+    private int databaseVersion = 0;
+
+    public void setVersion(int version) {
+        databaseVersion = version;
+    }
+
+    public enum DatabaseType {
+        SQLITE,
+        MYSQL,
+        MARIADB
+    }
+    
+}

--- a/api/src/main/java/ovh/mythmc/social/api/context/SocialMessageContext.java
+++ b/api/src/main/java/ovh/mythmc/social/api/context/SocialMessageContext.java
@@ -1,5 +1,6 @@
 package ovh.mythmc.social.api.context;
 
+import java.util.Optional;
 import java.util.Set;
 
 import javax.annotation.Nullable;
@@ -31,8 +32,13 @@ public class SocialMessageContext implements SocialContext {
 
     private final @Nullable SignedMessage signedMessage;
 
+    @Deprecated(forRemoval = true)
     public boolean isSigned() {
         return signedMessage != null;
+    }
+
+    public Optional<SignedMessage> signedMessage() {
+        return Optional.ofNullable(signedMessage);
     }
 
     public boolean isReply() {

--- a/api/src/main/java/ovh/mythmc/social/api/database/persister/AdventureStylePersister.java
+++ b/api/src/main/java/ovh/mythmc/social/api/database/persister/AdventureStylePersister.java
@@ -1,0 +1,47 @@
+package ovh.mythmc.social.api.database.persister;
+
+import java.sql.SQLException;
+
+import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.field.SqlType;
+import com.j256.ormlite.field.types.StringType;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
+
+public final class AdventureStylePersister extends StringType {
+    
+    private static final AdventureStylePersister INSTANCE = new AdventureStylePersister();
+
+    private AdventureStylePersister() {
+        super(SqlType.STRING, new Class<?>[] { Style.class });
+    }
+
+    public static AdventureStylePersister getSingleton() {
+        return INSTANCE;
+    }
+
+    @Override
+    public Object javaToSqlArg(FieldType fieldType, Object javaObject) throws SQLException {
+        return getStringFromStyle((Style) javaObject);
+    }
+
+    @Override
+    public Object sqlArgToJava(FieldType fieldType, Object sqlArg, int columnPos) throws SQLException {
+        return sqlArg != null ? getStyleFromString((String) sqlArg) : null;
+    }
+
+    private String getStringFromStyle(Style style) {
+        final var dummyComponent = Component.empty()
+            .style(style);
+
+        return GsonComponentSerializer.gson().serialize(dummyComponent);
+    }
+
+    private Style getStyleFromString(String string) {
+        return GsonComponentSerializer.gson().deserialize(string)
+            .style();
+    }
+
+}

--- a/api/src/main/java/ovh/mythmc/social/api/text/group/SocialParserGroup.java
+++ b/api/src/main/java/ovh/mythmc/social/api/text/group/SocialParserGroup.java
@@ -55,6 +55,23 @@ public class SocialParserGroup implements SocialUserInputParser {
         return processor.parse(context.withGroup(Optional.of(this))); 
     }
 
+    @SuppressWarnings("unchecked")
+    public <T extends SocialContextualParser> List<T> getByType(@NotNull Class<T> type) {
+        final List<T> typeParsers = new ArrayList<>();
+
+        content.stream()
+            .filter(parser -> type.isInstance(parser))
+            .map(parser -> (T) parser)
+            .forEach(typeParsers::add);
+
+        content.stream() // Recursive search
+            .filter(parser -> parser instanceof SocialParserGroup)
+            .map(parser -> (SocialParserGroup) parser)
+            .forEach(group -> group.getByType(type).forEach(typeParsers::add));
+
+        return typeParsers;
+    }
+
     @Override
     public Component parse(SocialParserContext context) {
         if (context instanceof SocialProcessorContext processorContext) {

--- a/api/src/main/java/ovh/mythmc/social/api/text/parser/SocialContextualKeyword.java
+++ b/api/src/main/java/ovh/mythmc/social/api/text/parser/SocialContextualKeyword.java
@@ -7,11 +7,16 @@ import net.kyori.adventure.text.TextReplacementConfig;
 import net.kyori.adventure.text.format.Style;
 import ovh.mythmc.social.api.context.SocialParserContext;
 
-public abstract class SocialContextualKeyword implements SocialUserInputParser {
+public abstract class SocialContextualKeyword implements SocialUserInputParser, SocialIdentifiedParser {
 
     public abstract String keyword();
 
     public abstract Component process(SocialParserContext context);
+
+    @Override
+    public String identifier() {
+        return keyword();
+    }
 
     @Override
     public Component parse(SocialParserContext context) {

--- a/api/src/main/java/ovh/mythmc/social/api/text/parser/SocialContextualParser.java
+++ b/api/src/main/java/ovh/mythmc/social/api/text/parser/SocialContextualParser.java
@@ -15,10 +15,9 @@ public interface SocialContextualParser {
 
     default boolean supportsOfflinePlayers() { return false; }
 
-    static Component request(@NotNull SocialParserContext context, @NotNull List<SocialContextualParser> requestedParsers) {
+    static Component requestList(@NotNull SocialParserContext context, @NotNull List<? extends SocialContextualParser> requestedParsers) {
         var message = context.message();
 
-        //List<SocialContextualParser> parsers = Social.get().getTextProcessor().getContextualParsersWithGroupMembers().stream().filter(p -> requestedParsers.contains(p)).toList();
         for (SocialContextualParser parser : requestedParsers) {
             message = parser.parse(context.withMessage(message));
         }
@@ -26,8 +25,12 @@ public interface SocialContextualParser {
         return message;
     }
 
+    @SuppressWarnings("unchecked")
     static Component request(@NotNull SocialParserContext context, final @NotNull Class<?>... requestedParsers) {
-        return request(context, Arrays.stream(requestedParsers).map(clazz -> Social.get().getTextProcessor().getContextualParserByClass(clazz)).toList());
+        return requestList(context, Arrays.stream(requestedParsers)
+            .filter(clazz -> SocialContextualParser.class.isAssignableFrom(clazz))
+            .map(clazz -> Social.get().getTextProcessor().getContextualParsersByType((Class<SocialContextualParser>) clazz).stream().findFirst().orElse(null))
+            .toList());
     }
 
 }

--- a/api/src/main/java/ovh/mythmc/social/api/text/parser/SocialContextualPlaceholder.java
+++ b/api/src/main/java/ovh/mythmc/social/api/text/parser/SocialContextualPlaceholder.java
@@ -6,9 +6,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextReplacementConfig;
 import ovh.mythmc.social.api.context.SocialParserContext;
 
-public abstract class SocialContextualPlaceholder implements SocialContextualParser {
-
-    public abstract String identifier();
+public abstract class SocialContextualPlaceholder implements SocialIdentifiedParser {
 
     public abstract Component get(SocialParserContext context);
 

--- a/api/src/main/java/ovh/mythmc/social/api/text/parser/SocialIdentifiedParser.java
+++ b/api/src/main/java/ovh/mythmc/social/api/text/parser/SocialIdentifiedParser.java
@@ -1,0 +1,7 @@
+package ovh.mythmc.social.api.text.parser;
+
+public interface SocialIdentifiedParser extends SocialContextualParser {
+
+    String identifier();
+    
+}

--- a/api/src/main/java/ovh/mythmc/social/api/user/SocialUser.java
+++ b/api/src/main/java/ovh/mythmc/social/api/user/SocialUser.java
@@ -5,7 +5,6 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.Style;
 
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -19,6 +18,7 @@ import ovh.mythmc.social.api.Social;
 import ovh.mythmc.social.api.chat.ChatChannel;
 import ovh.mythmc.social.api.chat.GroupChatChannel;
 import ovh.mythmc.social.api.context.SocialParserContext;
+import ovh.mythmc.social.api.database.persister.AdventureStylePersister;
 
 import java.util.ArrayList;
 import java.util.Optional;
@@ -54,8 +54,9 @@ public class SocialUser implements SocialUserAudienceWrapper {
     private long latestMessageInMilliseconds;
 
     @DatabaseField(columnName = "cachedNickname")
-    private String cachedNickname;
+    private String cachedDisplayName;
 
+    @DatabaseField(persisterClass = AdventureStylePersister.class)
     private Style displayNameStyle;
 
     @Getter(AccessLevel.PRIVATE)
@@ -102,7 +103,7 @@ public class SocialUser implements SocialUserAudienceWrapper {
     }
 
     public Component displayName() {
-        var displayName = Component.text(cachedNickname);
+        var displayName = Component.text(cachedDisplayName);
 
         if (displayNameStyle != null)
             return displayName.style(displayNameStyle);
@@ -112,10 +113,7 @@ public class SocialUser implements SocialUserAudienceWrapper {
 
     @Deprecated(forRemoval = true)
     public String getNickname() {
-        if (player().isPresent())
-            cachedNickname = ChatColor.stripColor(player().get().getDisplayName());
-
-        return cachedNickname;
+        return cachedDisplayName;
     }
 
     // Send social messages

--- a/api/src/main/java/ovh/mythmc/social/api/user/SocialUserCompanion.java
+++ b/api/src/main/java/ovh/mythmc/social/api/user/SocialUserCompanion.java
@@ -82,7 +82,7 @@ public final class SocialUserCompanion {
         user.player().ifPresent(player -> {
             var bytes = encode(
                 channel.getName().getBytes(StandardCharsets.UTF_8),
-                sender.getCachedNickname().getBytes(StandardCharsets.UTF_8),
+                sender.getCachedDisplayName().getBytes(StandardCharsets.UTF_8),
                 sender.getUuid().toString().getBytes(StandardCharsets.UTF_8)
             );
     

--- a/api/src/main/java/ovh/mythmc/social/api/user/SocialUserCompanion.java
+++ b/api/src/main/java/ovh/mythmc/social/api/user/SocialUserCompanion.java
@@ -82,7 +82,7 @@ public final class SocialUserCompanion {
         user.player().ifPresent(player -> {
             var bytes = encode(
                 channel.getName().getBytes(StandardCharsets.UTF_8),
-                sender.getNickname().getBytes(StandardCharsets.UTF_8),
+                sender.getCachedNickname().getBytes(StandardCharsets.UTF_8),
                 sender.getUuid().toString().getBytes(StandardCharsets.UTF_8)
             );
     

--- a/api/src/main/java/ovh/mythmc/social/api/user/SocialUserManager.java
+++ b/api/src/main/java/ovh/mythmc/social/api/user/SocialUserManager.java
@@ -117,7 +117,7 @@ public final class SocialUserManager {
     }
 
     public void setDisplayName(final @NotNull SocialUser user, final @NotNull String displayName) {
-        user.setCachedNickname(displayName);
+        user.setCachedDisplayName(displayName);
         user.player().ifPresent(player -> player.setDisplayName(displayName));
 
         SocialDatabase.get().update(user);

--- a/api/src/main/java/ovh/mythmc/social/api/user/SocialUserManager.java
+++ b/api/src/main/java/ovh/mythmc/social/api/user/SocialUserManager.java
@@ -2,6 +2,8 @@ package ovh.mythmc.social.api.user;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import net.kyori.adventure.text.format.Style;
+
 import org.bukkit.Bukkit;
 import org.jetbrains.annotations.NotNull;
 import ovh.mythmc.social.api.Social;
@@ -110,6 +112,19 @@ public final class SocialUserManager {
                              final boolean socialSpy) {
 
         user.setSocialSpy(socialSpy);
+
+        SocialDatabase.get().update(user);
+    }
+
+    public void setDisplayName(final @NotNull SocialUser user, final @NotNull String displayName) {
+        user.setCachedNickname(displayName);
+        user.player().ifPresent(player -> player.setDisplayName(displayName));
+
+        SocialDatabase.get().update(user);
+    }
+
+    public void setDisplayNameStyle(final @NotNull SocialUser user, final Style style) {
+        user.setDisplayNameStyle(style);
 
         SocialDatabase.get().update(user);
     }

--- a/platform-bukkit/src/main/java/ovh/mythmc/social/bukkit/SocialBukkit.java
+++ b/platform-bukkit/src/main/java/ovh/mythmc/social/bukkit/SocialBukkit.java
@@ -58,6 +58,7 @@ public final class SocialBukkit extends SocialBootstrap<SocialBukkitPlugin> {
     @Override
     public void shutdown() {
         gestalt.terminate();
+        super.shutdown();
     }
 
     @Override

--- a/platform-common/src/main/java/ovh/mythmc/social/common/adapter/ChatEventAdapter.java
+++ b/platform-common/src/main/java/ovh/mythmc/social/common/adapter/ChatEventAdapter.java
@@ -142,7 +142,7 @@ public abstract class ChatEventAdapter<E extends PlayerEvent & Cancellable> impl
                 registeredMessage.message().applyFallbackStyle(Style.style(ClickEvent.suggestCommand("(re:#" + idToReply + ") "))), 
                 registeredMessage.rawMessage(), 
                 registeredMessage.replyId(),
-                registeredMessage.signedMessage())
+                registeredMessage.signedMessage().orElse(null))
         );
 
         // Update sender's latest message

--- a/platform-common/src/main/java/ovh/mythmc/social/common/boot/SocialBootstrap.java
+++ b/platform-common/src/main/java/ovh/mythmc/social/common/boot/SocialBootstrap.java
@@ -84,7 +84,9 @@ public abstract class SocialBootstrap<T> implements Social {
 
     public abstract void enable();
 
-    public abstract void shutdown();
+    public void shutdown() {
+        SocialDatabase.get().shutdown();
+    }
 
     @Override
     public final void reload(ReloadType type) {

--- a/platform-common/src/main/java/ovh/mythmc/social/common/command/base/GroupBaseCommand.java
+++ b/platform-common/src/main/java/ovh/mythmc/social/common/command/base/GroupBaseCommand.java
@@ -27,7 +27,7 @@ public final class GroupBaseCommand {
             return;
         }
 
-        Social.get().getChatManager().setGroupChannelAlias(user.getGroupChatChannel(), alias);
+        Social.get().getChatManager().setGroupChannelAlias(user.group().get(), alias);
         Social.get().getTextProcessor().parseAndSend(user, Social.get().getConfig().getMessages().getCommands().getGroupAliasChanged(), Social.get().getConfig().getMessages().getChannelType());
     }
 
@@ -35,7 +35,7 @@ public final class GroupBaseCommand {
     @Permission(value = "social.use.group.chat", def = PermissionDefault.TRUE)
     @Requirement(value = "group", messageKey = "not-in-group")
     public void chat(SocialUser user) {
-        Social.get().getUserManager().setMainChannel(user, user.getGroupChatChannel());
+        Social.get().getUserManager().setMainChannel(user, user.group().get());
     }
 
     @Command("code")
@@ -70,7 +70,7 @@ public final class GroupBaseCommand {
     public void disband(SocialUser user, Flags flags) {
         if (flags.hasFlag("c")) {
             Social.get().getTextProcessor().parseAndSend(user, Social.get().getConfig().getMessages().getCommands().getGroupDisbanded(), Social.get().getConfig().getMessages().getChannelType());
-            Social.get().getChatManager().unregisterChatChannel(user.getGroupChatChannel());
+            Social.get().getChatManager().unregisterChatChannel(user.group().get());
             return;
         }
 
@@ -105,7 +105,7 @@ public final class GroupBaseCommand {
             return;
         }
 
-        user.getGroupChatChannel().removeMember(target);
+        user.group().get().removeMember(target);
     }
 
     @Command("leader")
@@ -118,25 +118,27 @@ public final class GroupBaseCommand {
             return;
         }
 
-        Social.get().getChatManager().setGroupChannelLeader(user.getGroupChatChannel(), target.getUuid());
+        Social.get().getChatManager().setGroupChannelLeader(user.group().get(), target.getUuid());
     }
 
     @Command("leave")
     @Permission(value = "social.use.group.leave", def = PermissionDefault.TRUE)
     @Requirement(value = "group", messageKey = "not-in-group")
     public void leave(SocialUser user) {
-        if (user.getGroupChatChannel().getLeaderUuid().equals(user.getUuid())) {
-            if (user.getGroupChatChannel().getMembers().size() < 2) {
-                Social.get().getChatManager().unregisterChatChannel(user.getGroupChatChannel());
+        final var group = user.group().get();
+
+        if (group.getLeaderUuid().equals(user.getUuid())) {
+            if (group.getMembers().size() < 2) {
+                Social.get().getChatManager().unregisterChatChannel(group);
                 Social.get().getTextProcessor().parseAndSend(user, Social.get().getConfig().getMessages().getCommands().getGroupDisbanded(), Social.get().getConfig().getMessages().getChannelType());
                 return;
             }
 
-            Social.get().getChatManager().setGroupChannelLeader(user.getGroupChatChannel(), user.getGroupChatChannel().getMemberUuids().get(1));
+            Social.get().getChatManager().setGroupChannelLeader(group, group.getMemberUuids().get(1));
         }
 
         Social.get().getTextProcessor().parseAndSend(user, Social.get().getConfig().getMessages().getCommands().getLeftGroup(), Social.get().getConfig().getMessages().getChannelType());
-        user.getGroupChatChannel().removeMember(user);
+        group.removeMember(user);
     }
     
 }

--- a/platform-common/src/main/java/ovh/mythmc/social/common/command/base/PMBaseCommand.java
+++ b/platform-common/src/main/java/ovh/mythmc/social/common/command/base/PMBaseCommand.java
@@ -17,7 +17,7 @@ public final class PMBaseCommand {
 
     @Command
     public void execute(SocialUser sender, SocialUser recipient, @Suggestion("formatting-options") @Join(" ") String plainMessage) {
-        var callback = new SocialPrivateMessageSend(recipient, recipient, plainMessage);
+        var callback = new SocialPrivateMessageSend(sender, recipient, plainMessage);
         SocialPrivateMessageSendCallback.INSTANCE.invoke(callback, result -> {
             if (!result.cancelled())
                 Social.get().getChatManager().sendPrivateMessage(result.sender(), result.recipient(), result.plainMessage());

--- a/platform-common/src/main/java/ovh/mythmc/social/common/command/base/SocialBaseCommand.java
+++ b/platform-common/src/main/java/ovh/mythmc/social/common/command/base/SocialBaseCommand.java
@@ -6,9 +6,11 @@ import org.bukkit.permissions.PermissionDefault;
 
 import dev.triumphteam.cmd.bukkit.annotation.Permission;
 import dev.triumphteam.cmd.core.annotations.Command;
+import dev.triumphteam.cmd.core.annotations.Description;
 import dev.triumphteam.cmd.core.annotations.Flag;
 import dev.triumphteam.cmd.core.annotations.Optional;
 import dev.triumphteam.cmd.core.annotations.Suggestion;
+import dev.triumphteam.cmd.core.annotations.Syntax;
 import dev.triumphteam.cmd.core.argument.keyed.Flags;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.ClickEvent;
@@ -38,12 +40,15 @@ import ovh.mythmc.social.common.gui.impl.KeywordDictionaryMenu;
 import ovh.mythmc.social.common.gui.impl.PlayerInfoMenu;
 
 @Command("social")
+@Description("Main command for social")
+@Syntax("/social test")
 public final class SocialBaseCommand {
 
     @Command("announce")
+    @Description("Announces a provided parsable message")
     @Permission(value = "social.use.announce", def = PermissionDefault.OP)
-    @Flag(flag = "s", longFlag = "self")
-    @Flag(flag = "t", longFlag = "channelType", argument = ChannelType.class)
+    @Flag(flag = "s", longFlag = "self", description = "Shows this message only to the sender")
+    @Flag(flag = "t", longFlag = "channelType", argument = ChannelType.class, description = "The channel type of this message")
     public void announce(SocialUser user, Flags flags) {
         final String message = flags.getText();
         final boolean self = flags.hasFlag("s");
@@ -62,8 +67,9 @@ public final class SocialBaseCommand {
     }
 
     @Command("announcement")
+    @Description("Announces a configured announcement")
     @Permission(value = "social.use.announcement", def = PermissionDefault.OP)
-    @Flag(flag = "s", longFlag = "self")
+    @Flag(flag = "s", longFlag = "self", description = "Shows this message only to the sender")
     public void announce(SocialUser user, @Suggestion("announcements") Integer id, Flags flags) {
         final int announcementsSize = Social.get().getAnnouncementManager().getAnnouncements().size();
         if (id > announcementsSize || id < 0) {
@@ -99,6 +105,7 @@ public final class SocialBaseCommand {
     }
 
     @Command("channel")
+    @Description("Switches your main channel")
     @Permission(value = "social.use.channel", def = PermissionDefault.TRUE)
     public void channel(SocialUser user, ChatChannel channel) {
         if (channel instanceof GroupChatChannel && !channel.getMemberUuids().contains(user.getUuid())) {
@@ -118,6 +125,7 @@ public final class SocialBaseCommand {
     }
 
     @Command("dictionary")
+    @Description("Opens the dictionary")
     @Permission(value = "social.use.dictionary", def = PermissionDefault.TRUE)
     public class Dictionary {
 
@@ -152,6 +160,7 @@ public final class SocialBaseCommand {
     }
 
     @Command("history")
+    @Description("Opens the chat history")
     @Permission("social.use.history")
     public class History {
 
@@ -215,6 +224,7 @@ public final class SocialBaseCommand {
     }
     
     @Command("info")
+    @Description("Opens the user information menu")
     @Permission("social.use.info")
     public void self(SocialUser user, @Optional SocialUser target) {
         SocialMenuContext context = SocialMenuContext.builder()
@@ -227,6 +237,7 @@ public final class SocialBaseCommand {
     }
 
     @Command("mute")
+    @Description("Mutes a user")
     @Permission(value = "social.use.mute", def = PermissionDefault.OP)
     public void mute(SocialUser user, SocialUser target, @Optional ChatChannel channel) {
         if (target.equals(user)) {
@@ -248,7 +259,7 @@ public final class SocialBaseCommand {
             Social.get().getUserManager().mute(target, channel);
 
             // Command sender
-            String successMessage = String.format(Social.get().getConfig().getMessages().getCommands().getUserMuted(), target.getCachedNickname());
+            String successMessage = String.format(Social.get().getConfig().getMessages().getCommands().getUserMuted(), target.getCachedDisplayName());
             Social.get().getTextProcessor().parseAndSend(user, channel, successMessage, Social.get().getConfig().getMessages().getChannelType());
 
             // Target
@@ -262,7 +273,7 @@ public final class SocialBaseCommand {
             Social.get().getChatManager().getChannels().forEach(registeredChannel -> Social.get().getUserManager().mute(target, registeredChannel));
 
             // Command sender
-            String successMessage = String.format(Social.get().getConfig().getMessages().getCommands().getUserMutedGlobally(), target.getCachedNickname());
+            String successMessage = String.format(Social.get().getConfig().getMessages().getCommands().getUserMutedGlobally(), target.getCachedDisplayName());
             Social.get().getTextProcessor().parseAndSend(user, user.getMainChannel(), successMessage, Social.get().getConfig().getMessages().getChannelType());
 
             // Target
@@ -271,6 +282,7 @@ public final class SocialBaseCommand {
     }
 
     @Command("unmute")
+    @Description("Unmutes a user")
     @Permission(value = "social.use.unmute", def = PermissionDefault.OP)
     public void unmute(SocialUser user, SocialUser target, @Optional ChatChannel channel) {
         if (channel != null) { // unmute in channel
@@ -282,7 +294,7 @@ public final class SocialBaseCommand {
             Social.get().getUserManager().unmute(target, channel);
 
             // Command sender
-            String successMessage = String.format(Social.get().getConfig().getMessages().getCommands().getUserUnmuted(), target.getCachedNickname());
+            String successMessage = String.format(Social.get().getConfig().getMessages().getCommands().getUserUnmuted(), target.getCachedDisplayName());
             Social.get().getTextProcessor().parseAndSend(user, channel, successMessage, Social.get().getConfig().getMessages().getChannelType());
 
             // Target
@@ -308,6 +320,7 @@ public final class SocialBaseCommand {
     public final class Nickname {
 
         @Command("set")
+        @Description("Sets a nickname")
         @Permission(value = "social.use.nickname.set", def = PermissionDefault.TRUE)
         public void set(SocialUser user, String nickname, @Optional SocialUser target) {
             if (nickname.length() > 16) {
@@ -347,6 +360,7 @@ public final class SocialBaseCommand {
         }
 
         @Command("color")
+        @Description("Sets your nickname color")
         @Permission(value = "social.use.nickname.color", def = PermissionDefault.OP)
         public void color(SocialUser user, TextColor color, @Optional SocialUser target) {
             if (color.asHexString().contains("dbdbdb"))
@@ -359,7 +373,7 @@ public final class SocialBaseCommand {
                 }
 
                 Social.get().getUserManager().setDisplayNameStyle(target, Style.style(color));
-                Social.get().getTextProcessor().parseAndSend(user, String.format(Social.get().getConfig().getMessages().getCommands().getNicknameChangedOthers(), target.player().get().getName(), target.getCachedNickname()), Social.get().getConfig().getMessages().getChannelType());
+                Social.get().getTextProcessor().parseAndSend(user, String.format(Social.get().getConfig().getMessages().getCommands().getNicknameChangedOthers(), target.player().get().getName(), target.getCachedDisplayName()), Social.get().getConfig().getMessages().getChannelType());
             } else { // Sender's nickname color
                 Social.get().getUserManager().setDisplayNameStyle(user, Style.style(color));
                 Social.get().getTextProcessor().parseAndSend(user, user.getMainChannel(), Social.get().getConfig().getMessages().getCommands().getNicknameChanged(), Social.get().getConfig().getMessages().getChannelType());
@@ -369,10 +383,12 @@ public final class SocialBaseCommand {
     }
 
     @Command("processor")
+    @Description("Accesses social's built-in text processor")
     @Permission(value = "social.use.processor", def = PermissionDefault.OP)
     public final class Processor {
 
         @Command("info")
+        @Description("Shows information about the text processor")
         @Permission("social.use.processor.info")
         public void info(SocialUser user) {
             final String registeredParsers = String.format(
@@ -387,11 +403,12 @@ public final class SocialBaseCommand {
         }
 
         @Command("parse")
+        @Description("Parses a message and returns it")
         @Permission("social.use.processor.parse")
-        @Flag(flag = "u", longFlag = "user", argument = SocialUser.class)
-        @Flag(flag = "c", longFlag = "channel", argument = ChatChannel.class)
-        @Flag(flag = "t", longFlag = "channelType", argument = ChannelType.class)
-        @Flag(flag = "p", longFlag = "playerInput", argument = boolean.class)
+        @Flag(flag = "u", longFlag = "user", argument = SocialUser.class, description = "User for the parser context")
+        @Flag(flag = "c", longFlag = "channel", argument = ChatChannel.class, description = "Channel for the parser context")
+        @Flag(flag = "t", longFlag = "channelType", argument = ChannelType.class, description = "Channel type for the parser context")
+        @Flag(flag = "i", longFlag = "userInput", argument = boolean.class, description = "Whether to treat this message as user's input")
         public void parse(SocialUser user, Flags flags) {
             final String input = flags.getText();
 
@@ -402,7 +419,7 @@ public final class SocialBaseCommand {
     
             final var parsedInput = Social.get().getTextProcessor().parse(context);
             if (context.messageChannelType().equals(ChannelType.ACTION_BAR)) {
-                user.sendParsableMessage(context, flags.getFlagValue("p", boolean.class).orElse(false));
+                user.sendParsableMessage(context, flags.getFlagValue("i", boolean.class).orElse(false));
                 return;
             }
 
@@ -417,12 +434,13 @@ public final class SocialBaseCommand {
         }
 
         @Command("get")
+        @Description("Gets a specific parser's result")
         @Permission(value = "social.use.processor.get", def = PermissionDefault.OP)
         public final class Get {
 
             @Command("placeholder")
             @Permission(value = "social.use.processor.get.placeholder", def = PermissionDefault.OP)
-            @Flag(flag = "u", longFlag = "user", argument = SocialUser.class)
+            @Flag(flag = "u", longFlag = "user", argument = SocialUser.class, description = "User for the parser's context")
             public void placeholder(SocialUser user, SocialContextualPlaceholder placeholder, Flags flags) {
                 final var target = flags.getFlagValue("u", SocialUser.class).orElse(user);
                 var context = SocialParserContext.builder(target, Component.empty()).build();
@@ -438,7 +456,7 @@ public final class SocialBaseCommand {
 
             @Command("keyword")
             @Permission(value = "social.use.processor.get.keyword", def = PermissionDefault.OP)
-            @Flag(flag = "u", longFlag = "user", argument = SocialUser.class)
+            @Flag(flag = "u", longFlag = "user", argument = SocialUser.class, description = "User for the parser's context")
             public void keyword(SocialUser user, SocialContextualKeyword keyword, Flags flags) {
                 final var target = flags.getFlagValue("u", SocialUser.class).orElse(user);
                 var context = SocialParserContext.builder(target, Component.empty()).build();
@@ -467,6 +485,7 @@ public final class SocialBaseCommand {
     }
 
     @Command("reload")
+    @Description("Reloads the plugin")
     @Permission("social.use.reload")
     public void reload(SocialUser user, @Optional ReloadType type) {
         type = java.util.Optional.ofNullable(type).orElse(ReloadType.ALL);
@@ -480,6 +499,7 @@ public final class SocialBaseCommand {
     }
 
     @Command("socialspy")
+    @Description("Toggles the socialspy status")
     @Permission("social.use.socialspy")
     public void socialSpy(SocialUser user) {
         Social.get().getUserManager().setSocialSpy(user, !user.isSocialSpy());

--- a/platform-common/src/main/java/ovh/mythmc/social/common/gui/impl/HistoryMenu.java
+++ b/platform-common/src/main/java/ovh/mythmc/social/common/gui/impl/HistoryMenu.java
@@ -102,7 +102,7 @@ public class HistoryMenu implements HistoryBookMenu {
             Component page = Component.empty();
 
             for (SocialRegisteredMessageContext message : messages) { 
-                Component hoverText = Component.text(message.sender().getCachedNickname() + ": ", NamedTextColor.GRAY)
+                Component hoverText = Component.text(message.sender().getCachedDisplayName() + ": ", NamedTextColor.GRAY)
                     .append(message.message()).color(NamedTextColor.WHITE)
                     .appendNewline()
                     .appendNewline()
@@ -122,7 +122,7 @@ public class HistoryMenu implements HistoryBookMenu {
 
                     Component replyMessage = Component.text("#" + reply.id())
                         .appendSpace()
-                        .append(Component.text("(" + reply.sender().getCachedNickname() + ")", NamedTextColor.BLUE)
+                        .append(Component.text("(" + reply.sender().getCachedDisplayName() + ")", NamedTextColor.BLUE)
                         .appendNewline()
                         .appendNewline()
                         .append(MiniMessage.miniMessage().deserialize(Social.get().getConfig().getMenus().getChatHistory().getClickToOpenThreadHistory()))

--- a/platform-common/src/main/java/ovh/mythmc/social/common/gui/impl/HistoryMenu.java
+++ b/platform-common/src/main/java/ovh/mythmc/social/common/gui/impl/HistoryMenu.java
@@ -102,7 +102,7 @@ public class HistoryMenu implements HistoryBookMenu {
             Component page = Component.empty();
 
             for (SocialRegisteredMessageContext message : messages) { 
-                Component hoverText = Component.text(message.sender().getNickname() + ": ", NamedTextColor.GRAY)
+                Component hoverText = Component.text(message.sender().getCachedNickname() + ": ", NamedTextColor.GRAY)
                     .append(message.message()).color(NamedTextColor.WHITE)
                     .appendNewline()
                     .appendNewline()
@@ -122,7 +122,7 @@ public class HistoryMenu implements HistoryBookMenu {
 
                     Component replyMessage = Component.text("#" + reply.id())
                         .appendSpace()
-                        .append(Component.text("(" + reply.sender().getNickname() + ")", NamedTextColor.BLUE)
+                        .append(Component.text("(" + reply.sender().getCachedNickname() + ")", NamedTextColor.BLUE)
                         .appendNewline()
                         .appendNewline()
                         .append(MiniMessage.miniMessage().deserialize(Social.get().getConfig().getMenus().getChatHistory().getClickToOpenThreadHistory()))

--- a/platform-common/src/main/java/ovh/mythmc/social/common/gui/impl/PlayerInfoMenu.java
+++ b/platform-common/src/main/java/ovh/mythmc/social/common/gui/impl/PlayerInfoMenu.java
@@ -30,7 +30,7 @@ public final class PlayerInfoMenu implements SimpleBookMenu {
 
         Component alias = getField(
             MiniMessage.miniMessage().deserialize(Social.get().getConfig().getMenus().getPlayerInfo().getAlias()), 
-            Component.text(context.target().getNickname())
+            Component.text(context.target().getCachedNickname())
         );
 
         Component username = getField(

--- a/platform-common/src/main/java/ovh/mythmc/social/common/gui/impl/PlayerInfoMenu.java
+++ b/platform-common/src/main/java/ovh/mythmc/social/common/gui/impl/PlayerInfoMenu.java
@@ -30,7 +30,7 @@ public final class PlayerInfoMenu implements SimpleBookMenu {
 
         Component alias = getField(
             MiniMessage.miniMessage().deserialize(Social.get().getConfig().getMenus().getPlayerInfo().getAlias()), 
-            Component.text(context.target().getCachedNickname())
+            Component.text(context.target().getCachedDisplayName())
         );
 
         Component username = getField(

--- a/platform-common/src/main/java/ovh/mythmc/social/common/hook/DiscordSRVHook.java
+++ b/platform-common/src/main/java/ovh/mythmc/social/common/hook/DiscordSRVHook.java
@@ -21,6 +21,7 @@ import ovh.mythmc.social.api.callback.message.SocialMessageSendCallback;
 import ovh.mythmc.social.api.chat.ChannelType;
 import ovh.mythmc.social.api.chat.ChatChannel;
 import ovh.mythmc.social.api.context.SocialParserContext;
+import ovh.mythmc.social.api.text.parser.SocialContextualPlaceholder;
 import ovh.mythmc.social.api.user.SocialUser;
 
 @RequiredArgsConstructor
@@ -52,7 +53,7 @@ public final class DiscordSRVHook implements ChatHook {
 
     @Subscribe // compatibility with Bukkit
     public void onGameChatMessagePostProcess(GameChatMessagePostProcessEvent event) {
-        if (event.getTriggeringBukkitEvent() instanceof AsyncPlayerChatEvent asyncPlayerChatEvent) {
+        if (event.getTriggeringBukkitEvent() instanceof AsyncPlayerChatEvent) {
             //if (chatEvent.getRecipients().isEmpty())
             event.setCancelled(true);
         }
@@ -71,7 +72,7 @@ public final class DiscordSRVHook implements ChatHook {
             .channel(chatChannel)
             .build();
 
-        TextComponent channelIcon =  (TextComponent) Social.get().getTextProcessor().getContextualPlaceholder("channel_icon").get().get(context);
+        TextComponent channelIcon =  (TextComponent) Social.get().getTextProcessor().getIdentifiedParser(SocialContextualPlaceholder.class, "channel_icon").get().get(context);
 
         miniMessage = miniMessage.replace("%channel%", channelIcon.content());
 

--- a/platform-common/src/main/java/ovh/mythmc/social/common/hook/PlaceholderAPIHook.java
+++ b/platform-common/src/main/java/ovh/mythmc/social/common/hook/PlaceholderAPIHook.java
@@ -72,7 +72,7 @@ public final class PlaceholderAPIHook implements SocialContextualParser, Listene
                     return groupChatChannel.getName();
                 }
                 if (params.equalsIgnoreCase("group_leader")) {
-                    return groupChatChannel.getLeader().getCachedNickname();
+                    return groupChatChannel.getLeader().getCachedDisplayName();
                 }
                 if (params.equalsIgnoreCase("group_leader_username")) {
                     return groupChatChannel.getLeader().player().get().getName();
@@ -110,7 +110,7 @@ public final class PlaceholderAPIHook implements SocialContextualParser, Listene
                     if (uuid == null)
                         return null;
 
-                    return Social.get().getUserManager().getByUuid(uuid).getCachedNickname();
+                    return Social.get().getUserManager().getByUuid(uuid).getCachedDisplayName();
                 }
             }
 

--- a/platform-common/src/main/java/ovh/mythmc/social/common/hook/PlaceholderAPIHook.java
+++ b/platform-common/src/main/java/ovh/mythmc/social/common/hook/PlaceholderAPIHook.java
@@ -72,7 +72,7 @@ public final class PlaceholderAPIHook implements SocialContextualParser, Listene
                     return groupChatChannel.getName();
                 }
                 if (params.equalsIgnoreCase("group_leader")) {
-                    return groupChatChannel.getLeader().getNickname();
+                    return groupChatChannel.getLeader().getCachedNickname();
                 }
                 if (params.equalsIgnoreCase("group_leader_username")) {
                     return groupChatChannel.getLeader().player().get().getName();
@@ -110,7 +110,7 @@ public final class PlaceholderAPIHook implements SocialContextualParser, Listene
                     if (uuid == null)
                         return null;
 
-                    return Social.get().getUserManager().getByUuid(uuid).getNickname();
+                    return Social.get().getUserManager().getByUuid(uuid).getCachedNickname();
                 }
             }
 

--- a/platform-common/src/main/java/ovh/mythmc/social/common/listener/ChatListener.java
+++ b/platform-common/src/main/java/ovh/mythmc/social/common/listener/ChatListener.java
@@ -130,7 +130,7 @@ public final class ChatListener implements Listener {
         });
 
         SocialChannelPostSwitchCallback.INSTANCE.registerListener(IdentifierKeys.CHANNEL_SWITCH_MESSAGE, (user, previousChannel, channel) -> {
-            if (user.isCompanion())
+            if (user.companion().isPresent())
                 return;
             
             SocialParserContext context = SocialParserContext.builder(user, Component.text(Social.get().getConfig().getMessages().getCommands().getChannelChanged()))

--- a/platform-common/src/main/java/ovh/mythmc/social/common/listener/CompanionListener.java
+++ b/platform-common/src/main/java/ovh/mythmc/social/common/listener/CompanionListener.java
@@ -86,7 +86,7 @@ public final class CompanionListener implements Listener, PluginMessageListener 
         });
 
         SocialChannelPostSwitchCallback.INSTANCE.registerHandler(IdentifierKeys.COMPANION_CHANNEL_SWITCH, (ctx) -> {
-            if (ctx.user().companion().isEmpty())
+            if (ctx.user().companion().isPresent())
                 ctx.user().companion().get().mainChannel(ctx.channel());
         });
     }

--- a/platform-common/src/main/java/ovh/mythmc/social/common/listener/MentionsListener.java
+++ b/platform-common/src/main/java/ovh/mythmc/social/common/listener/MentionsListener.java
@@ -38,7 +38,7 @@ public final class MentionsListener {
             // Username
             message = message.replaceText((builder) -> {
                 builder
-                    .match(Pattern.quote("@" + ctx.recipient().player().get().getName()) + "|" + Pattern.quote("@" + ctx.recipient().getCachedNickname()))
+                    .match(Pattern.quote("@" + ctx.recipient().player().get().getName()) + "|" + Pattern.quote("@" + ctx.recipient().getCachedDisplayName()))
                     .replacement((match, textBuilder) -> {
                         wrapper.mentioned = true;
                         return Component.text(match.group()).color(ctx.channel().getColor());

--- a/platform-common/src/main/java/ovh/mythmc/social/common/listener/MentionsListener.java
+++ b/platform-common/src/main/java/ovh/mythmc/social/common/listener/MentionsListener.java
@@ -38,7 +38,7 @@ public final class MentionsListener {
             // Username
             message = message.replaceText((builder) -> {
                 builder
-                    .match(Pattern.quote("@" + ctx.recipient().player().get().getName()) + "|" + Pattern.quote("@" + ctx.recipient().getNickname()))
+                    .match(Pattern.quote("@" + ctx.recipient().player().get().getName()) + "|" + Pattern.quote("@" + ctx.recipient().getCachedNickname()))
                     .replacement((match, textBuilder) -> {
                         wrapper.mentioned = true;
                         return Component.text(match.group()).color(ctx.channel().getColor());
@@ -48,8 +48,7 @@ public final class MentionsListener {
             if (wrapper.mentioned) {
                 ctx.recipient().playSound(getSoundByKey(Social.get().getConfig().getChat().getMentionSound()));
                 
-                if (ctx.recipient().isCompanion())
-                    ctx.recipient().getCompanion().mention(ctx.channel(), ctx.sender());
+                ctx.recipient().companion().ifPresent(companion -> companion.mention(ctx.channel(), ctx.sender()));
             }
 
             ctx.message(message);

--- a/platform-common/src/main/java/ovh/mythmc/social/common/listener/SocialUserListener.java
+++ b/platform-common/src/main/java/ovh/mythmc/social/common/listener/SocialUserListener.java
@@ -1,14 +1,10 @@
 package ovh.mythmc.social.common.listener;
 
-import org.bukkit.NamespacedKey;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerLoginEvent;
-import org.bukkit.event.player.PlayerQuitEvent;
-import org.bukkit.persistence.PersistentDataContainer;
-import org.bukkit.persistence.PersistentDataType;
 
 import ovh.mythmc.social.api.Social;
 import ovh.mythmc.social.api.configuration.LegacySocialSettings;
@@ -20,9 +16,6 @@ import java.util.Collection;
 import java.util.UUID;
 
 public final class SocialUserListener implements Listener {
-
-    // Temporary workaround for nicknames
-    NamespacedKey key = new NamespacedKey("social", "nickname");
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onPlayerLogin(PlayerLoginEvent event) {
@@ -36,14 +29,9 @@ public final class SocialUserListener implements Listener {
     @EventHandler(priority = EventPriority.LOWEST)
     public void onPlayerJoin(PlayerJoinEvent event) {
         SocialUser user = Social.get().getUserManager().getByUuid(event.getPlayer().getUniqueId());
-
-        // Temporary workaround for nicknames
-        PersistentDataContainer container = user.player().get().getPersistentDataContainer();
-        if (container.has(key, PersistentDataType.STRING)) {
-            String nickname = container.get(key, PersistentDataType.STRING);
-            user.player().get().setDisplayName(nickname);
-            user.getNickname(); // Updates cached nickname
-        }
+        
+        // Set nickname
+        user.player().get().setDisplayName(user.getCachedNickname());
 
         // Emoji chat completions
         if (Social.get().getConfig().getEmojis().isEnabled() && Social.get().getConfig().getGeneral().isChatEmojiTabCompletion())
@@ -63,8 +51,9 @@ public final class SocialUserListener implements Listener {
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
+    @SuppressWarnings("deprecation")
     public void onAdminJoin(PlayerJoinEvent event) {
-        if (!event.getPlayer().hasPermission("social.use.reload"))
+        if (!event.getPlayer().hasPermission("social.use.reload")) // Checks if user is admin
             return;
 
         SocialSettings settings = Social.get().getConfig().getSettings();
@@ -76,13 +65,6 @@ public final class SocialUserListener implements Listener {
             user.sendParsableMessage("$(info_prefix) <yellow>This server is running an outdated settings file! Please, back up and delete your current settings.yml to regenerate a clean setup.</yellow>");   
             user.sendParsableMessage("$(info_prefix) <blue>Hint:</blue> <gray>You can disable this message by setting 'nagAdmins' to false.</gray>");
         }
-    }
-
-    @EventHandler
-    public void onPlayerQuit(PlayerQuitEvent event) {
-        PersistentDataContainer container = event.getPlayer().getPersistentDataContainer();
-
-        container.set(key, PersistentDataType.STRING, event.getPlayer().getDisplayName());
     }
 
 }

--- a/platform-common/src/main/java/ovh/mythmc/social/common/listener/SocialUserListener.java
+++ b/platform-common/src/main/java/ovh/mythmc/social/common/listener/SocialUserListener.java
@@ -30,8 +30,8 @@ public final class SocialUserListener implements Listener {
     public void onPlayerJoin(PlayerJoinEvent event) {
         SocialUser user = Social.get().getUserManager().getByUuid(event.getPlayer().getUniqueId());
         
-        // Set nickname
-        user.player().get().setDisplayName(user.getCachedNickname());
+        // Update display name
+        user.player().get().setDisplayName(user.getCachedDisplayName());
 
         // Emoji chat completions
         if (Social.get().getConfig().getEmojis().isEnabled() && Social.get().getConfig().getGeneral().isChatEmojiTabCompletion())

--- a/platform-common/src/main/java/ovh/mythmc/social/common/text/placeholder/group/GroupCodePlaceholder.java
+++ b/platform-common/src/main/java/ovh/mythmc/social/common/text/placeholder/group/GroupCodePlaceholder.java
@@ -4,7 +4,6 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEvent;
 import ovh.mythmc.social.api.Social;
-import ovh.mythmc.social.api.chat.GroupChatChannel;
 import ovh.mythmc.social.api.context.SocialParserContext;
 import ovh.mythmc.social.api.text.parser.SocialContextualParser;
 import ovh.mythmc.social.api.text.parser.SocialContextualPlaceholder;
@@ -24,8 +23,8 @@ public final class GroupCodePlaceholder extends SocialContextualPlaceholder {
 
     @Override
     public Component get(SocialParserContext context) {
-        GroupChatChannel groupChatChannel = context.user().getGroupChatChannel();
-        if (groupChatChannel == null)
+        final var optionalGroup = context.user().group();
+        if (optionalGroup.isEmpty())
             return Component.empty();
 
         Component hoverText = Component.text(Social.get().getConfig().getChat().getGroups().getCodeHoverText());
@@ -33,9 +32,9 @@ public final class GroupCodePlaceholder extends SocialContextualPlaceholder {
             MiniMessageParser.class
         );
         
-        return Component.text(groupChatChannel.getCode())
+        return Component.text(optionalGroup.get().getCode())
             .hoverEvent(HoverEvent.showText(hoverText))
-            .clickEvent(ClickEvent.copyToClipboard(groupChatChannel.getCode() + ""));
+            .clickEvent(ClickEvent.copyToClipboard(optionalGroup.get().getCode() + ""));
     }
 
 }

--- a/platform-common/src/main/java/ovh/mythmc/social/common/text/placeholder/group/GroupIconPlaceholder.java
+++ b/platform-common/src/main/java/ovh/mythmc/social/common/text/placeholder/group/GroupIconPlaceholder.java
@@ -1,7 +1,6 @@
 package ovh.mythmc.social.common.text.placeholder.group;
 
 import net.kyori.adventure.text.Component;
-import ovh.mythmc.social.api.chat.GroupChatChannel;
 import ovh.mythmc.social.api.context.SocialParserContext;
 import ovh.mythmc.social.api.text.parser.SocialContextualPlaceholder;
 
@@ -19,11 +18,11 @@ public final class GroupIconPlaceholder extends SocialContextualPlaceholder {
 
     @Override
     public Component get(SocialParserContext context) {
-        GroupChatChannel groupChatChannel = context.user().getGroupChatChannel();
-        if (groupChatChannel == null)
+        final var optionalGroup = context.user().group();
+        if (optionalGroup.isEmpty())
             return Component.empty();
 
-        return Component.text(groupChatChannel.getIcon());
+        return Component.text(optionalGroup.get().getIcon());
     }
 
 }

--- a/platform-common/src/main/java/ovh/mythmc/social/common/text/placeholder/group/GroupLeaderPlaceholder.java
+++ b/platform-common/src/main/java/ovh/mythmc/social/common/text/placeholder/group/GroupLeaderPlaceholder.java
@@ -4,7 +4,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 
 import net.kyori.adventure.text.Component;
-import ovh.mythmc.social.api.chat.GroupChatChannel;
 import ovh.mythmc.social.api.context.SocialParserContext;
 import ovh.mythmc.social.api.text.parser.SocialContextualPlaceholder;
 
@@ -22,11 +21,11 @@ public final class GroupLeaderPlaceholder extends SocialContextualPlaceholder {
 
     @Override
     public Component get(SocialParserContext context) {
-        GroupChatChannel groupChatChannel = context.user().getGroupChatChannel();
-        if (groupChatChannel == null)
+        final var optionalGroup = context.user().group();
+        if (optionalGroup.isEmpty())
             return Component.empty();
 
-        return Component.text(ChatColor.stripColor(Bukkit.getPlayer(groupChatChannel.getLeaderUuid()).getDisplayName()));
+        return Component.text(ChatColor.stripColor(Bukkit.getPlayer(optionalGroup.get().getLeaderUuid()).getDisplayName()));
     }
 
 }

--- a/platform-common/src/main/java/ovh/mythmc/social/common/text/placeholder/group/GroupPlaceholder.java
+++ b/platform-common/src/main/java/ovh/mythmc/social/common/text/placeholder/group/GroupPlaceholder.java
@@ -1,7 +1,6 @@
 package ovh.mythmc.social.common.text.placeholder.group;
 
 import net.kyori.adventure.text.Component;
-import ovh.mythmc.social.api.chat.GroupChatChannel;
 import ovh.mythmc.social.api.context.SocialParserContext;
 import ovh.mythmc.social.api.text.parser.SocialContextualPlaceholder;
 
@@ -19,14 +18,14 @@ public final class GroupPlaceholder extends SocialContextualPlaceholder {
 
     @Override
     public Component get(SocialParserContext context) {
-        GroupChatChannel groupChatChannel = context.user().getGroupChatChannel();
-        if (groupChatChannel == null)
+        final var optionalGroup = context.user().group();
+        if (optionalGroup.isEmpty())
             return Component.empty();
 
-        if (groupChatChannel.getAlias() != null)
-            return Component.text(groupChatChannel.getAlias());
+        if (optionalGroup.get().getAlias() != null)
+            return Component.text(optionalGroup.get().getAlias());
 
-        return Component.text(groupChatChannel.getName());
+        return Component.text(optionalGroup.get().getName());
     }
 
 }

--- a/platform-common/src/main/java/ovh/mythmc/social/common/text/placeholder/player/ClickableNicknamePlaceholder.java
+++ b/platform-common/src/main/java/ovh/mythmc/social/common/text/placeholder/player/ClickableNicknamePlaceholder.java
@@ -26,7 +26,7 @@ public final class ClickableNicknamePlaceholder extends SocialContextualPlacehol
         SocialUser user = context.user();
 
         String hoverTextAsString = Social.get().getConfig().getChat().getClickableNicknameHoverText();
-        if (!user.getCachedNickname().equals(user.player().get().getName())) {
+        if (!user.getCachedDisplayName().equals(user.player().get().getName())) {
             hoverTextAsString = hoverTextAsString + "\n" + Social.get().getConfig().getChat().getPlayerAliasWarningHoverText();
         }
 

--- a/platform-common/src/main/java/ovh/mythmc/social/common/text/placeholder/player/ClickableNicknamePlaceholder.java
+++ b/platform-common/src/main/java/ovh/mythmc/social/common/text/placeholder/player/ClickableNicknamePlaceholder.java
@@ -26,7 +26,7 @@ public final class ClickableNicknamePlaceholder extends SocialContextualPlacehol
         SocialUser user = context.user();
 
         String hoverTextAsString = Social.get().getConfig().getChat().getClickableNicknameHoverText();
-        if (!user.getNickname().equals(user.player().get().getName())) {
+        if (!user.getCachedNickname().equals(user.player().get().getName())) {
             hoverTextAsString = hoverTextAsString + "\n" + Social.get().getConfig().getChat().getPlayerAliasWarningHoverText();
         }
 
@@ -43,10 +43,10 @@ public final class ClickableNicknamePlaceholder extends SocialContextualPlacehol
         );
 
         if (commandAsString.isEmpty())
-            return Component.text(user.getNickname())
+            return user.displayName()
                 .hoverEvent(hoverText);
 
-        return Component.text(user.getNickname())
+        return user.displayName()
             .clickEvent(ClickEvent.suggestCommand("/" + commandAsString))
             .hoverEvent(hoverText);
     }

--- a/platform-common/src/main/java/ovh/mythmc/social/common/text/placeholder/player/NicknamePlaceholder.java
+++ b/platform-common/src/main/java/ovh/mythmc/social/common/text/placeholder/player/NicknamePlaceholder.java
@@ -18,7 +18,7 @@ public final class NicknamePlaceholder extends SocialContextualPlaceholder {
 
     @Override
     public Component get(SocialParserContext context) {
-        return Component.text(context.user().getNickname());
+        return context.user().displayName();
     }
 
 }

--- a/platform-paper/src/main/java/ovh/mythmc/social/paper/SocialPaper.java
+++ b/platform-paper/src/main/java/ovh/mythmc/social/paper/SocialPaper.java
@@ -57,6 +57,7 @@ public final class SocialPaper extends SocialBootstrap<SocialPaperPlugin> {
     @Override
     public void shutdown() {
         gestalt.terminate();
+        super.shutdown();
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
 
     <profiles>
         <profile>
-            <id>release</id>
+            <id>central-release</id>
             <build>
                 <plugins>
                     <plugin>
@@ -181,10 +181,19 @@
             </build>
         </profile>
         <profile>
-            <id>snapshot</id>
+            <id>release</id>
             <distributionManagement>
                 <repository>
                     <id>myth-mc-releases</id>
+                    <url>https://repo.mythmc.ovh/releases</url>
+                </repository>
+            </distributionManagement>
+        </profile>
+        <profile>
+            <id>snapshot</id>
+            <distributionManagement>
+                <repository>
+                    <id>myth-mc-snapshots</id>
                     <url>https://repo.mythmc.ovh/snapshots</url>
                 </repository>
             </distributionManagement>


### PR DESCRIPTION
- [x] Adds command `/social processor`, which exposes some built-in features of social's text processor to server administrators
- [x] Adds command `/social nickname color <color/hex color> (optional player)`, which allows users with permission `social.use.nickname.color` to customize their nickname color 
- [x] Adds the interface `SocialIdentifiedParser`, which allows the parser to be identified with a unique string
- [x] Various enhancements to `CustomTextProcessor`(and `GlobalTextProcessor` by extension)
  - Method `CustomTextProcessor::getContextualParsersByType`, which replaces `GlobalTextProcessor::getContextualParserByClass` and searches recursively
  - Method `CustomTextProcessor::getGroupByContextualParser`, which returns the group of a registered parser
  - Method `CustomTextProcessor::getIdentifiedContextualParser`, which gets a `SocialIdentifiedParser` by its unique identifier
- [x] Method `SocialParserGroup::getByType`, which provides the same functionality as `CustomTextProcessor::getContextualParsersByType` without having to build a text processor
- [x] Method `SocialUserManager::setDisplayName` and `SocialUserManager::setDisplayNameStyle`
- [x] Fixes an issue where private messages showed the recipient as the sender
- [x] Fixes an issue where command `/social announcement <id>` wouldn't filter out wrong args
- [x] Fixes an issue where display names in replies were unparsed 
- [x] Removes unused legacy code leftovers  
- [x] Method `SocialMessageContext::signedMessage` now returns an `Optional` containing a `SignedMessage`
- [x] Methods `SocialUser::getCompanion` and `SocialUser::isCompanion` have been deprecated in favor of `SocialUser::companion`, which returns an `Optional` containing a `SocialUserCompanion`
- [x] Method `SocialUser::getNickname` has been deprecated in favor of `SocialUser::getCachedDisplayName`, since display names are actually cached in the database since version 0.4.0

**To-do:**
- [x] Nicknames aren't properly recovered between sessions