### PR TITLE
Update GlobalTextProcessor.java

### DIFF
--- a/api/src/main/java/ovh/mythmc/social/api/text/GlobalTextProcessor.java
+++ b/api/src/main/java/ovh/mythmc/social/api/text/GlobalTextProcessor.java
@@ -357,12 +357,18 @@ public final class GlobalTextProcessor {
             return;
 
         switch (type) {
-            case ACTION_BAR -> members.forEach(user -> user.audience().sendActionBar(message));
+            case ACTION_BAR -> members.forEach(user -> {
+            if (user.audience() == null) return;
+                user.audience().sendActionBar(message);
+            });
             case CHAT -> members.forEach(user -> {
-                final Component userMessage = user.companion().isPresent()
-                        ? (channel == null ? CompanionModUtils.asBroadcast(message)
-                                : CompanionModUtils.asChannelable(message, channel))
-                        : message;
+                if (user.audience() == null) return;
+
+            final Component userMessage = user.companion().isPresent()
+                ? (channel == null ? CompanionModUtils.asBroadcast(message)
+                    : CompanionModUtils.asChannelable(message, channel))
+                    : message;
+
                 user.audience().sendMessage(userMessage);
             });
         }


### PR DESCRIPTION
Fix NullPointerException in GlobalTextProcessor.send()

Problem:
The server was crashing when sending messages through the Social plugin because user.audience() could be null in some cases (e.g., disconnected players or uninitialized SocialUser objects).

Solution:
Added a null check before calling any methods on user.audience(). Messages are skipped safely for users without an audience, preventing NPEs and server crashes.

Changes:
- GlobalTextProcessor.send(Collection<SocialUser>, Component, ChannelType, ChatChannel): added `if (user.audience() == null) return;` for both CHAT and ACTION_BAR cases.
- GlobalTextProcessor.send(SocialUser, Component, ChannelType, ChatChannel): delegated to the collection method (already protected).

Impact:
- Prevents server crashes on chat events.
- Normal message delivery works unchanged for connected players.
- Safe for players with companions or special mod integrations.